### PR TITLE
Add Bounds property binder and organize inspector

### DIFF
--- a/Packages/jp.keijiro.smrvfx/Runtime/SkinnedMeshBaker.cs
+++ b/Packages/jp.keijiro.smrvfx/Runtime/SkinnedMeshBaker.cs
@@ -19,6 +19,8 @@ public sealed partial class SkinnedMeshBaker : MonoBehaviour
     (Matrix4x4 current, Matrix4x4 previous) _rootMatrix;
     Mesh _tempMesh;
 
+    Bounds _bounds;
+
     #endregion
 
     #region MonoBehaviour implementation
@@ -95,6 +97,11 @@ public sealed partial class SkinnedMeshBaker : MonoBehaviour
 
         // Transform matrix history
         _rootMatrix.previous = _rootMatrix.current;
+
+        // Update bounds
+        _bounds = _sources[0].bounds;
+        for (int i = 1; i < _sources.Length; ++i)
+            _bounds.Encapsulate(_sources[i].bounds);
     }
 
     #endregion

--- a/Packages/jp.keijiro.smrvfx/Runtime/SkinnedMeshBakerProperties.cs
+++ b/Packages/jp.keijiro.smrvfx/Runtime/SkinnedMeshBakerProperties.cs
@@ -26,6 +26,7 @@ public sealed partial class SkinnedMeshBaker : MonoBehaviour
     public Texture VelocityMap => _velocityMap;
     public Texture NormalMap => _normalMap;
     public int VertexCount => _pointCount;
+    public Bounds Bounds => _bounds;
 
     #endregion
 

--- a/Packages/jp.keijiro.smrvfx/Runtime/SkinnedMeshBinder.cs
+++ b/Packages/jp.keijiro.smrvfx/Runtime/SkinnedMeshBinder.cs
@@ -28,32 +28,67 @@ namespace Smrvfx
             set => _vertexCountProperty = value;
         }
 
+        public string BoundsProperty {
+            get => (string)_boundsProperty;
+            set
+            {
+                _boundsProperty = value;
+                UpdateSubProperties();
+            }
+        }
+
+        [Header("Position Map")]
         [VFXPropertyBinding("UnityEngine.Texture2D"), SerializeField]
         ExposedProperty _positionMapProperty = "PositionMap";
 
+        [Header("Velocity Map")]
         public bool _bindVelocityMap = false;
 
         [VFXPropertyBinding("UnityEngine.Texture2D"), SerializeField]
         ExposedProperty _velocityMapProperty = "VelocityMap";
 
+        [Header("Normal Map")]
         public bool _bindNormalMap = false;
 
         [VFXPropertyBinding("UnityEngine.Texture2D"), SerializeField]
         ExposedProperty _normalMapProperty = "NormalMap";
 
+        [Header("Vertex Count")]
         public bool _bindVertexCount = false;
 
         [VFXPropertyBinding("System.UInt32"), SerializeField]
         ExposedProperty _vertexCountProperty = "VertexCount";
 
+        [Header("Bounds")]
+        public bool _bindBounds = false;
+
+        [Range(0, 10)]
+        [Tooltip("Expands the bounding box in every direction by given distance.")]
+        public float _boundsExpansion;
+
+        [Tooltip("Name of the AABox property to bind to.")]
+        [VFXPropertyBinding("UnityEditor.VFX.AABox"), SerializeField]
+        ExposedProperty _boundsProperty = "Bounds_size";
+
+        [Space(32)]
         public SkinnedMeshBaker Target = null;
+
+        ExposedProperty _boundsCenterProperty;
+        ExposedProperty _boundsSizeProperty;
+
+        protected override void OnEnable()
+        {
+            UpdateSubProperties();
+            base.OnEnable();
+        }
 
         public override bool IsValid(VisualEffect component)
           => Target != null &&
            component.HasTexture(_positionMapProperty) &&
            (!_bindVelocityMap || component.HasTexture(_velocityMapProperty)) &&
            (!_bindNormalMap   || component.HasTexture(_normalMapProperty)) &&
-           (!_bindVertexCount || component.HasUInt(_vertexCountProperty));
+           (!_bindVertexCount || component.HasUInt(_vertexCountProperty)) &&
+           (!_bindBounds      || component.HasVector3(_boundsCenterProperty) && component.HasVector3(_boundsSizeProperty));
 
         public override void UpdateBinding(VisualEffect component)
         {
@@ -67,6 +102,23 @@ namespace Smrvfx
 
             if (_bindVertexCount)
                 component.SetUInt(_vertexCountProperty, (uint)Target.VertexCount);
+
+            if (_bindBounds)
+            {
+                var bounds = Target.Bounds;
+                bounds.Expand(_boundsExpansion);
+                component.SetVector3(_boundsCenterProperty, bounds.center);
+                component.SetVector3(_boundsSizeProperty, bounds.size);
+            }
+        }
+
+        void OnValidate()
+            => UpdateSubProperties();
+
+        void UpdateSubProperties()
+        {
+            _boundsCenterProperty = _boundsProperty + "_center";
+            _boundsSizeProperty = _boundsProperty + "_size";
         }
 
         public override string ToString()


### PR DESCRIPTION
This commit adds a bounds property to the SkinnedMeshBinder, allowing you to easily deal with a situation where the character moves away from the point of origin. It allows you to select an exposed AABox graph property that you can easily connect to the effect's bounds input. There's an additional slider for expanding the bounds (since usually the VFX bounds should be larger than the mesh bounds). I also organized the inspector a little because I found it confusing at first sight.

![image](https://user-images.githubusercontent.com/13803120/94960995-1ffae600-04f4-11eb-986c-8132e760ec81.png)

Usage of the bound property looks like this:

![image](https://user-images.githubusercontent.com/13803120/94961127-5d5f7380-04f4-11eb-862c-257bd80341d7.png)
